### PR TITLE
Remove runtime pin on ipywidgets

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,4 @@
 @ECHO ON
 del pyproject.toml
-%PYTHON% -m pip install --no-deps -vv --install-option="--skip-npm" . || exit 1
+set JUPYTER_PACKAGING_SKIP_NPM=1
+%PYTHON% -m pip install --no-deps -vv . || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -eux
 rm pyproject.toml
-${PYTHON} -m pip install --no-deps -vv --install-option="--skip-npm" .
+export JUPYTER_PACKAGING_SKIP_NPM=1
+${PYTHON} -m pip install --no-deps -vv .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 48de3fc13c7a012f586b6713fdef61858e925291775f2b287eb017e00e7fc17d
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - pip
     - python >=3.6
   run:
-    - ipywidgets >=7.6.0,<8.0.0
+    - ipywidgets >=7.6.0
     - numpy
     - python >=3.6
     - pillow


### PR DESCRIPTION
Because not all releases are pinned, the effect of this pin is to simply get the latest unpinned version, 0.3.1, which is _still broken_ with ipywidgets 8.

In any case, this version, 0.3.3, is supposed to have fixed compatibility with ipywidgets 8, https://github.com/vispy/jupyter_rfb/pull/64.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.